### PR TITLE
fix color not working for yeelight color 3

### DIFF
--- a/defFiles/yeelink.light.color3.js
+++ b/defFiles/yeelink.light.color3.js
@@ -57,7 +57,11 @@ module.exports = class extends Device {
     }
 
     setColorHSV(v) {
-        this._miioCall('set_hsv', withLightEffect([v.hue, v.saturation]));
+        return this.miioCall('set_hsv', withLightEffect([v.hue, v.saturation]));
+    }
+	
+    setColorRGB(v) {
+        return this.miioCall('set_rgb', withLightEffect([v]));
     }
 
 };

--- a/defFiles/yeelink.light.color3.js
+++ b/defFiles/yeelink.light.color3.js
@@ -61,6 +61,7 @@ module.exports = class extends Device {
     }
 	
     setColorRGB(v) {
+		//If you don't want a fade effect change the end to withLightEffect([v],{ms:0})
         return this.miioCall('set_rgb', withLightEffect([v]));
     }
 

--- a/defFiles/yeelink.light.color3.js
+++ b/defFiles/yeelink.light.color3.js
@@ -61,7 +61,7 @@ module.exports = class extends Device {
     }
 	
     setColorRGB(v) {
-		//If you don't want a fade effect change the end to withLightEffect([v],{ms:0})
+        //If you don't want a fade effect change the end to withLightEffect([v],{ms:0})
         return this.miioCall('set_rgb', withLightEffect([v]));
     }
 

--- a/nodes/devices.js
+++ b/nodes/devices.js
@@ -177,8 +177,7 @@ module.exports = function(RED) {
               await device.init();
             };
             // F.2) transfer command from input into device (in AWAIT mode)
-            JsonItemX = [key] + "(" + CustomJsonCMD[key] + ")";
-            await eval("device.set" + JsonItemX);
+            await device["set" + key](CustomJsonCMD[key]);
             device.destroy();  
           } catch(exception) {
             // F.3) catching errors from MIIO Protocol and sending back to send-node


### PR DESCRIPTION
fix for #14
also added the option to use `{"ColorRGB":16711680}` //just an example that gives red.
so people can use `(msg.payload.color.r*65536)+(msg.payload.color.g*256)+msg.payload.color.b;`
for example, if they are already working with RGB values instead of a bigger rgb2hsv function.